### PR TITLE
Update Cloud-Manager_Deploy_Guide.md

### DIFF
--- a/cloud-manager/deploy/doc/Cloud-Manager_Deploy_Guide.md
+++ b/cloud-manager/deploy/doc/Cloud-Manager_Deploy_Guide.md
@@ -256,7 +256,7 @@ sh service.sh stop
 8.测试
 ======
 
-Cloud-Manager 是一个web服务.如果部署成功,可以通过网址(例:http://192.168.0.2:9999)访问.
+Cloud-Manager 是一个web服务.如果部署成功,可以通过网址(例:http://192.168.0.2:9999/cloud-manager)访问.
 
 注意: 请用真实配置的IP和端口访问,上文只是示例!
 


### PR DESCRIPTION
在centos7部署服务时，只有通过http://192.168.0.2:9999/cloud-manager才能正常访问，否则出现404错误